### PR TITLE
complete user story for private wikis.

### DIFF
--- a/app/helpers/wikis_helper.rb
+++ b/app/helpers/wikis_helper.rb
@@ -1,2 +1,11 @@
 module WikisHelper
+  def display_wiki_content?(wiki)
+    (wiki.private && (wiki.user == current_user || current_user.admin?)) || !wiki.private
+  end
+  def user_authorized_for_private?(wiki)
+    ((wiki.user == current_user || !wiki.user) && current_user.premium?) || current_user.admin?
+  end
+  def display_in_index?(wiki)
+    wiki.user != current_user && display_wiki_content?(wiki)
+  end
 end

--- a/app/views/wikis/_form.html.haml
+++ b/app/views/wikis/_form.html.haml
@@ -1,7 +1,7 @@
 = form_for [current_user, @wiki] do |f|
   = f.text_field :title
   = f.text_area :body
-  -if current_user.premium? || current_user.admin?
+  -if user_authorized_for_private?(@wiki)
     = f.check_box :private
   = f.submit
   = link_to "Cancel", (request.referer || user_wikis_path(current_user))

--- a/app/views/wikis/_private.html.haml
+++ b/app/views/wikis/_private.html.haml
@@ -1,0 +1,4 @@
+-if wiki.private
+  %br
+  .private
+    private

--- a/app/views/wikis/index.html.haml
+++ b/app/views/wikis/index.html.haml
@@ -7,10 +7,7 @@
           .panel
             %h6= link_to "#{wiki.title}", user_wiki_path(current_user, wiki)
             %small= wiki.body
-            -if wiki.private
-              %br
-              .private
-                private
+            = render partial: 'wikis/private', locals: {wiki: wiki}
     - if @wikis
       %h1
         -if current_user.wikis.size > 0
@@ -18,10 +15,11 @@
         -else
           All Wikis
         - @wikis.each do |wiki|
-          .panel
-            -unless wiki.private
+          -if display_in_index?(wiki)
+            .panel
               %h6= link_to "#{wiki.title}", user_wiki_path(current_user, wiki)
               %small= wiki.body
+              = render partial: 'wikis/private', locals: {wiki: wiki}
     - else
       %h1 No Wikis In Existence
       %h3 Create a Wiki for anything you wish

--- a/app/views/wikis/show.html.haml
+++ b/app/views/wikis/show.html.haml
@@ -1,14 +1,19 @@
 .row
-  .large-8.columns
-    -if @wiki.private && @wiki.user == current_user
+  -if display_wiki_content?(@wiki)
+    .large-8.columns
+
       %h1= @wiki.title
       %p= @wiki.body
-    -else
+
+    .large-4.columns.down-right
+      = link_to "Back to Wikis", user_wikis_path(current_user), class: 'button success radius'
+      %a{ :href => "#", :'data-dropdown' => 'drop1', :class => 'button dropdown secondary radius'}Edit Wiki
+      %br
+      %ul{ id: 'drop1', class: 'f-dropdown' }
+        %li= link_to "Edit wiki content", edit_user_wiki_path(current_user, @wiki)
+        %li= link_to "Delete wiki", [current_user, @wiki], method: :delete, data: {confirm: 'Are you sure you want to delete this wiki?'}
+  -else
+    .large-8.columns
       %h1 This is a private wiki.
-  .large-4.columns.down-right
-    = link_to "Back to Wikis", user_wikis_path(current_user), class: 'button success radius'
-    %a{ :href => "#", :'data-dropdown' => 'drop1', :class => 'button dropdown secondary radius'}Edit Wiki
-    %br
-    %ul{ id: 'drop1', class: 'f-dropdown' }
-      %li= link_to "Edit wiki content", edit_user_wiki_path(current_user, @wiki)
-      %li= link_to "Delete wiki", [current_user, @wiki], method: :delete, data: {confirm: 'Are you sure you want to delete this wiki?'}
+    .large-4.columns.down-right
+      = link_to "Back to Wikis", user_wikis_path(current_user), class: 'button success radius'


### PR DESCRIPTION
Updated views with these authorizations:
- standard users: can view their own wikis(public or made private by an admin) and all other public wikis, will not see the private checkbox in new or edit forms
- premium users: can view all wikis, will see the private checkbox if they are creating a new wiki or editing one of their own wikis.
- admin users: have all privileges.

Features already included: 
- a premium users private wikis will become public when they downgrade.
- premium and admin users are able to create private wikis
- if a standard user navigates to the show view of a private wiki, they will not be able to see the wiki content
